### PR TITLE
Hotfix for error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@
 #
 # Internal variables
 #
-VERSION=0.0.1
+VERSION=0.0.2
 NAME=webpay
 SVC=$(NAME)-api
 BIN_PATH=$(PWD)/bin

--- a/pkg/webpay/webpay.go
+++ b/pkg/webpay/webpay.go
@@ -25,7 +25,7 @@ func New(privateCert, publicCert string, commerceCode int64, commerceEmail, serv
 func new(c *configuration) *Webpay {
 	w := &Webpay{
 		config:     c,
-		SOAPSigner: sign.New(c.PublicCert, c.PrivateCert),
+		SOAPSigner: sign.New(c.PrivateCert, c.PublicCert),
 	}
 
 	return w


### PR DESCRIPTION
Fix error in sign.New() params

`2020/05/04 05:49:45 asn1: structure error: tags don't match (16 vs {class:0 tag:2 length:1 isCompound:false}) {optional:false explicit:false application:false private:false defaultValue:<nil> tag:<nil> stringType:0 timeType:0 set:false omitEmpty:false} tbsCertificate @2`